### PR TITLE
Fix restaurant page build

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,5 +1,5 @@
-const path = require('path')
-const helpers = require('./src/helpers')
+const path = require("path")
+const helpers = require("./src/helpers")
 
 exports.createPages = ({ graphql, actions }) => {
   const { createPage } = actions
@@ -41,13 +41,16 @@ exports.createPages = ({ graphql, actions }) => {
     }
   `).then(result => {
     result.data.allAirtable.edges.forEach(({ node }) => {
-      createPage({
-        path: helpers.pageNameByNode(node.data),
-        component: path.resolve('./src/templates/restaurant.js'),
-        context: {
-          data: node
-        }
-      });
-    });
-  });
-};
+      const pagePath = helpers.pageNameByNode(node.data)
+      if (pagePath) {
+        createPage({
+          path: pagePath,
+          component: path.resolve("./src/templates/restaurant.js"),
+          context: {
+            data: node,
+          },
+        })
+      }
+    })
+  })
+}

--- a/src/components/RestaurantThumb/index.js
+++ b/src/components/RestaurantThumb/index.js
@@ -9,30 +9,31 @@ const RestaurantThumb = ({ data }) => {
     Foto_da_Comida: photos,
     Nome_do_Estabelecimento: name,
     Categoria: categories,
-  } = data;
+  } = data
 
-  const photo = (photos && photos.length && photos[0].thumbnails) || null;
+  const photo = (photos && photos.length && photos[0].thumbnails) || null
 
   return (
     <div className={styles.container}>
-      {photo &&
+      {photo && (
         <div className={styles.thumbnail} key={photo.full.url}>
           <Link to={pageNameByNode(data)}>
             <img src={photo.full.url} alt={`Foto de ${name}.`} />
           </Link>
         </div>
-      }
+      )}
 
       <h3 className={styles.title}>{name}</h3>
       <p className={styles.tag}>
-        {
-          categories.map((category, index) => (
-            <span key={category}>{category}{index < categories.length - 1 && ','} </span>
-          ))
-        }
+        {categories?.map((category, index) => (
+          <span key={category}>
+            {category}
+            {index < categories.length - 1 && ","}{" "}
+          </span>
+        ))}
       </p>
     </div>
   )
 }
 
-export default RestaurantThumb;
+export default RestaurantThumb


### PR DESCRIPTION
The `gatsby-node` was breaking the build in cases of the data not having `Instagram` or `Nome_do_Estabelecimento` in order to create a `pagePath` for gatsby. - aba4477

The RestaurantThumb was throwing an error because of a restaurant without categories. - 
aea4c85