### PR TITLE
Adding cloudfront invalidation inside buildspect as a post_build

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,3 +13,4 @@ phases:
   post_build:
     commands:
       - aws s3 sync public s3://$S3_BUCKET --delete
+      - aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION --paths "/*"


### PR DESCRIPTION
System received post_build command to generate a cloudfront
invalidation.