### PR TITLE
Disable cloudfront invalidation before IAM settings in AWS

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,4 +13,4 @@ phases:
   post_build:
     commands:
       - aws s3 sync public s3://$S3_BUCKET --delete
-      - aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION --paths "/*"
+      # - aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION --paths "/*"


### PR DESCRIPTION
Missing permissions to enable codebuild to command cloudfront
invalidation operation.